### PR TITLE
Fix merge order to match 2048 behavior

### DIFF
--- a/Assets/Scripts/Board/BoardController.cs
+++ b/Assets/Scripts/Board/BoardController.cs
@@ -31,6 +31,20 @@ namespace Board
                     yield return new Vector2Int(x, y);
         }
 
+        public IEnumerable<Vector2Int> AllCellsTopRightToBottomLeft()
+        {
+            for (int y = H - 1; y >= 0; y--)
+                for (int x = W - 1; x >= 0; x--)
+                    yield return new Vector2Int(x, y);
+        }
+
+        public IEnumerable<Vector2Int> AllCellsBottomLeftToTopRight()
+        {
+            for (int y = 0; y < H; y++)
+                for (int x = 0; x < W; x++)
+                    yield return new Vector2Int(x, y);
+        }
+
         public List<Vector2Int> EmptyCells()
         {
             var list = new List<Vector2Int>();

--- a/Assets/Scripts/Systems/MergeSystem.cs
+++ b/Assets/Scripts/Systems/MergeSystem.cs
@@ -20,9 +20,11 @@ namespace Systems
                     if (board.Grid[x, y] != null) board.Grid[x, y].mergedThisStep = false;
 
             // 2) Compute iteration order opposite to move direction so pushing is correct
-            IEnumerable<Vector2Int> order = dir == BoardController.Right || dir == BoardController.Up
-                ? board.AllCellsTopLeftToBottomRight()
-                : board.AllCellsBottomRightToTopLeft();
+            IEnumerable<Vector2Int> order =
+                dir == BoardController.Right ? board.AllCellsTopRightToBottomLeft() :
+                dir == BoardController.Left ? board.AllCellsBottomLeftToTopRight() :
+                dir == BoardController.Up ? board.AllCellsTopLeftToBottomRight() :
+                board.AllCellsBottomRightToTopLeft();
 
             foreach (var cell in order)
             {


### PR DESCRIPTION
## Summary
- add board traversal helpers for all corners
- ensure merge iteration matches move direction so merges prioritize movement

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fdb8edfc8330af5957b9c3118d32