### PR TITLE
Add upgrade tile runtime skeleton

### DIFF
--- a/Assets/Scripts/Upgrades.meta
+++ b/Assets/Scripts/Upgrades.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f77ccd96effceb6c30197e61d03e544b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/EventContext.cs
+++ b/Assets/Scripts/Upgrades/EventContext.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using Board;
+
+namespace Upgrades
+{
+    // Base class for all event contexts dispatched through GameEventBus.
+    public abstract class EventContext
+    {
+        public int turnIndex;
+    }
+
+    public class TurnContext : EventContext
+    {
+        public int rngSeed;
+        public int playerHP;
+        public int stageIndex;
+    }
+
+    public class MergeContext : EventContext
+    {
+        public TileData aTile;
+        public TileData bTile;
+        public TileData resultTile;
+        public Vector2Int position;
+        public int sumBeforeRule;
+        public int sumAfterRule;
+    }
+}

--- a/Assets/Scripts/Upgrades/EventContext.cs.meta
+++ b/Assets/Scripts/Upgrades/EventContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac9f5bd7dec9b81d7aefeab0a09e6ec8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/GameEventBus.cs
+++ b/Assets/Scripts/Upgrades/GameEventBus.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Upgrades
+{
+    // Simple synchronous event bus.
+    public class GameEventBus
+    {
+        public event Action<TriggerTiming, EventContext> OnEvent;
+
+        public void Publish(TriggerTiming timing, EventContext context)
+        {
+            OnEvent?.Invoke(timing, context);
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/GameEventBus.cs.meta
+++ b/Assets/Scripts/Upgrades/GameEventBus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00e12ca2cec23602d4a1bbf2ae446ff8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/RuntimeUpgradeState.cs
+++ b/Assets/Scripts/Upgrades/RuntimeUpgradeState.cs
@@ -1,0 +1,13 @@
+namespace Upgrades
+{
+    // Stores mutable runtime data for each upgrade tile instance.
+    public class RuntimeUpgradeState
+    {
+        public int lastTriggeredTurn = -1;
+        public int nextAvailableTurn = 0;
+        public int remainingCharges = -1;
+        public int triggeredThisTurn = -1;
+        public int creationOrder = 0;
+        public int lastTriggerFrame = -1;
+    }
+}

--- a/Assets/Scripts/Upgrades/RuntimeUpgradeState.cs.meta
+++ b/Assets/Scripts/Upgrades/RuntimeUpgradeState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 211c3f9f16f8927da7e7f145d639d2c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/TriggerTiming.cs
+++ b/Assets/Scripts/Upgrades/TriggerTiming.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Upgrades
+{
+    // Timing keys for upgrade tile triggers. Order is fixed for determinism.
+    public enum TriggerTiming
+    {
+        TurnStart,
+        TurnEnd,
+        OnSpawn,
+        OnMove,
+        OnMergePre,
+        OnMergePost,
+        OnEnemyTurnStart,
+        OnEnemyTurnEnd,
+        OnTrapTriggered,
+        OnEnemySpawn,
+        OnBoardFull,
+        OnBoardClear,
+        OnStageStart,
+        OnStageClear,
+        OnPeriodicN,
+        OnPlayerDeath,
+        Passive
+    }
+}

--- a/Assets/Scripts/Upgrades/TriggerTiming.cs.meta
+++ b/Assets/Scripts/Upgrades/TriggerTiming.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f14fdded771ccff4f888d1adc47a0577
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/UpgradeDispatcher.cs
+++ b/Assets/Scripts/Upgrades/UpgradeDispatcher.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+
+namespace Upgrades
+{
+    // Processes events and executes upgrade tile effects in deterministic order.
+    public class UpgradeDispatcher
+    {
+        private readonly UpgradeRegistry registry;
+        private readonly GameEventBus bus;
+        private readonly Dictionary<UpgradeTile, RuntimeUpgradeState> states = new();
+        private int creationCounter = 0;
+        private const int safetyLimit = 256;
+        private int currentFrame = 0;
+
+        public UpgradeDispatcher(GameEventBus bus, UpgradeRegistry registry)
+        {
+            this.bus = bus;
+            this.registry = registry;
+            bus.OnEvent += Handle;
+        }
+
+        private RuntimeUpgradeState GetState(UpgradeTile tile)
+        {
+            if (!states.TryGetValue(tile, out var state))
+            {
+                state = new RuntimeUpgradeState
+                {
+                    creationOrder = creationCounter++,
+                    remainingCharges = tile.charges
+                };
+                states[tile] = state;
+            }
+            return state;
+        }
+
+        private void Handle(TriggerTiming timing, EventContext context)
+        {
+            currentFrame++;
+            var candidates = registry.GetTilesForTiming(timing);
+            var eval = new List<(UpgradeTile tile, RuntimeUpgradeState state)>();
+
+            foreach (var tile in candidates)
+            {
+                var state = GetState(tile);
+                if (!EvaluateConditions(tile, context)) continue;
+                if (!CheckConstraints(tile, state, context.turnIndex)) continue;
+                eval.Add((tile, state));
+            }
+
+            eval.Sort((a, b) =>
+            {
+                int cmp = a.tile.priority.CompareTo(b.tile.priority);
+                if (cmp != 0) return cmp;
+                cmp = a.tile.y.CompareTo(b.tile.y);
+                if (cmp != 0) return cmp;
+                cmp = a.tile.x.CompareTo(b.tile.x);
+                if (cmp != 0) return cmp;
+                return a.state.creationOrder.CompareTo(b.state.creationOrder);
+            });
+
+            int fireCount = 0;
+            foreach (var (tile, state) in eval)
+            {
+                if (fireCount++ >= safetyLimit) break;
+                bool changed = ExecuteEffects(tile, context);
+                if (changed)
+                {
+                    state.lastTriggeredTurn = context.turnIndex;
+                    state.triggeredThisTurn = context.turnIndex;
+                    state.nextAvailableTurn = context.turnIndex + tile.cooldownTurns;
+                    state.lastTriggerFrame = currentFrame;
+                    if (state.remainingCharges > 0) state.remainingCharges--;
+                }
+            }
+        }
+
+        private bool EvaluateConditions(UpgradeTile tile, EventContext ctx)
+        {
+            // TODO: evaluate condition data. For now, always true.
+            return true;
+        }
+
+        private bool CheckConstraints(UpgradeTile tile, RuntimeUpgradeState state, int turn)
+        {
+            if (state.lastTriggerFrame == currentFrame) return false; // re-entry guard
+            if (tile.oncePerTurn && state.triggeredThisTurn == turn) return false;
+            if (turn < state.nextAvailableTurn) return false;
+            if (state.remainingCharges == 0) return false;
+            return true;
+        }
+
+        private bool ExecuteEffects(UpgradeTile tile, EventContext ctx)
+        {
+            // TODO: implement concrete effect logic; stub assumes any effect changes state.
+            bool changed = false;
+            foreach (var eff in tile.effects)
+                changed = true;
+            return changed;
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/UpgradeDispatcher.cs.meta
+++ b/Assets/Scripts/Upgrades/UpgradeDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a71f960ffa72bd4c7ca2c1aebe3bbf7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/UpgradeRegistry.cs
+++ b/Assets/Scripts/Upgrades/UpgradeRegistry.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace Upgrades
+{
+    // Maintains the currently "active" upgrade tiles and provides lookup by timing.
+    public class UpgradeRegistry
+    {
+        private readonly List<UpgradeTile> active = new();
+        private readonly Dictionary<TriggerTiming, List<UpgradeTile>> timingIndex = new();
+        private bool dirty = true;
+
+        public void Register(UpgradeTile tile)
+        {
+            active.Add(tile);
+            dirty = true;
+        }
+
+        public void Unregister(UpgradeTile tile)
+        {
+            active.Remove(tile);
+            dirty = true;
+        }
+
+        public IEnumerable<UpgradeTile> AllTiles => active;
+
+        private void Rebuild()
+        {
+            timingIndex.Clear();
+            foreach (var tile in active)
+            {
+                foreach (var t in tile.triggers)
+                {
+                    if (!timingIndex.TryGetValue(t, out var list))
+                        timingIndex[t] = list = new List<UpgradeTile>();
+                    list.Add(tile);
+                }
+            }
+            dirty = false;
+        }
+
+        public IReadOnlyList<UpgradeTile> GetTilesForTiming(TriggerTiming timing)
+        {
+            if (dirty) Rebuild();
+            return timingIndex.TryGetValue(timing, out var list) ? list : System.Array.Empty<UpgradeTile>();
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/UpgradeRegistry.cs.meta
+++ b/Assets/Scripts/Upgrades/UpgradeRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6f5017e4bd4694994ea0f46eb3bd730
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Upgrades/UpgradeTile.cs
+++ b/Assets/Scripts/Upgrades/UpgradeTile.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace Upgrades
+{
+    // Definition data for an upgrade tile instance.
+    public class UpgradeTile
+    {
+        public string id;
+        public string displayName;
+        public List<TriggerTiming> triggers = new();
+        public int priority = 0;
+        public int cooldownTurns = 0;
+        public int charges = -1;
+        public bool oncePerTurn = false;
+        public bool stackable = true;
+        public List<EffectData> effects = new();
+        public List<ConditionData> conditions = new();
+        public TargetSelectorData targetSelector;
+        public Dictionary<string, float> values = new();
+        public List<string> tags = new();
+
+        // Runtime placement info for sorting (row-major order)
+        public int x;
+        public int y;
+    }
+
+    // Effect definition
+    public class EffectData
+    {
+        public string type;
+        public Dictionary<string, float> @params = new();
+        public int repeats = 1;
+    }
+
+    // Condition definition (all AND)
+    public class ConditionData
+    {
+        public string type;
+        public Dictionary<string, float> @params = new();
+    }
+
+    // Target selector definition
+    public class TargetSelectorData
+    {
+        public string type;
+        public Dictionary<string, float> @params = new();
+    }
+}

--- a/Assets/Scripts/Upgrades/UpgradeTile.cs.meta
+++ b/Assets/Scripts/Upgrades/UpgradeTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6510874e6211620f5b1c25604708f80d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- introduce TriggerTiming enum and data classes for upgrade tiles
- wire up GameEventBus, UpgradeRegistry and UpgradeDispatcher skeleton
- add runtime state container for upgrade execution control

## Testing
- `dotnet test` (fails: command not found)
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689b1471fe688330a86bb86f44b2403c