### PR TITLE
Refactor upgrade effects to event-driven spec

### DIFF
--- a/Assets/Scripts/Data/UpgradeSpec.cs
+++ b/Assets/Scripts/Data/UpgradeSpec.cs
@@ -1,14 +1,22 @@
+using System.Collections.Generic;
 using UnityEngine;
+using Upgrades;
 
 namespace Data
 {
-    public enum UpgradeEffect { Add, Multiply, Max, Abs, DoubleMerge }
-
     [CreateAssetMenu(menuName = "Vibe/Data/UpgradeSpec")]
     public class UpgradeSpec : ScriptableObject
     {
         public int id;
         public string displayName;
-        public UpgradeEffect effect;
+        public List<UpgradeEffectSpec> effects = new();
+    }
+
+    [System.Serializable]
+    public class UpgradeEffectSpec
+    {
+        public TriggerTiming timing;
+        public string type;
+        public int period = 1; // Used when timing == OnPeriodicN
     }
 }

--- a/Assets/Scripts/Systems/MergeSystem.cs
+++ b/Assets/Scripts/Systems/MergeSystem.cs
@@ -106,18 +106,18 @@ namespace Systems
                         // NEW: Apply upgrade effect if any side is Upgrade
                         if (t.tag == TileTag.Upgrade)
                         {
-                            var eff = ResolveEffectFromId(t.upgradeSpecId);
+                            var spec = ResolveSpecFromId(t.upgradeSpecId);
                             int level = Mathf.Max(1, t.upgradeLevel);
-                            result = (upgradeSystem != null)
-                                ? upgradeSystem.Apply(eff, a, b, level)
+                            result = (upgradeSystem != null && spec != null)
+                                ? upgradeSystem.Apply(spec, a, b, level)
                                 : Mathf.Max(a, b) + 1;
                         }
                         else if (other.tag == TileTag.Upgrade)
                         {
-                            var eff = ResolveEffectFromId(other.upgradeSpecId);
+                            var spec = ResolveSpecFromId(other.upgradeSpecId);
                             int level = Mathf.Max(1, other.upgradeLevel);
-                            result = (upgradeSystem != null)
-                                ? upgradeSystem.Apply(eff, a, b, level)
+                            result = (upgradeSystem != null && spec != null)
+                                ? upgradeSystem.Apply(spec, a, b, level)
                                 : Mathf.Max(a, b) + 1;
                         }
                         else
@@ -171,11 +171,12 @@ namespace Systems
             return movedOrMerged;
         }
 
-        // Map UpgradeSpec.id -> UpgradeEffect enum (0..4)
-        private UpgradeEffect ResolveEffectFromId(int id)
+        // Lookup UpgradeSpec by id
+        private UpgradeSpec ResolveSpecFromId(int id)
         {
-            if (id < 0 || id > 4) return UpgradeEffect.Add;
-            return (UpgradeEffect)id;
+            if (wildSystem != null && wildSystem.TryGetUpgradeSpec(id, out var spec))
+                return spec;
+            return null;
         }
     }
 }

--- a/Assets/Scripts/Systems/UpgradeSystem.cs
+++ b/Assets/Scripts/Systems/UpgradeSystem.cs
@@ -1,4 +1,5 @@
 using Data;
+using Upgrades;
 using UnityEngine;
 
 namespace Systems
@@ -6,16 +7,32 @@ namespace Systems
     public class UpgradeSystem
     {
         // effect: 승급 타일이 합체에 참여할 때의 결과값 계산
-        public int Apply(UpgradeEffect effect, int a, int b, int level /*1 or 2*/)
+        public int Apply(UpgradeSpec spec, int a, int b, int level /*1 or 2*/)
         {
-            // level==2(승급+)는 보너스를 주도록 간단 가중
-            switch (effect)
+            if (spec == null)
+                return Mathf.Max(a, b) + 1;
+
+            UpgradeEffectSpec mergeEffect = null;
+            foreach (var eff in spec.effects)
             {
-                case UpgradeEffect.Add: return a + b + (level == 2 ? 1 : 0);
-                case UpgradeEffect.Multiply: return a * b + (level == 2 ? 1 : 0);
-                case UpgradeEffect.Max: return Mathf.Max(a, b) + (level == 2 ? 1 : 0);
-                case UpgradeEffect.Abs: return Mathf.Abs(a) + Mathf.Abs(b) + (level == 2 ? 0 : 0);
-                case UpgradeEffect.DoubleMerge:
+                if (eff.timing == TriggerTiming.OnMergePre || eff.timing == TriggerTiming.OnMergePost)
+                {
+                    mergeEffect = eff;
+                    break;
+                }
+            }
+
+            if (mergeEffect == null)
+                return Mathf.Max(a, b) + 1;
+
+            // level==2(승급+)는 보너스를 주도록 간단 가중
+            switch (mergeEffect.type)
+            {
+                case "Add": return a + b + (level == 2 ? 1 : 0);
+                case "Multiply": return a * b + (level == 2 ? 1 : 0);
+                case "Max": return Mathf.Max(a, b) + (level == 2 ? 1 : 0);
+                case "Abs": return Mathf.Abs(a) + Mathf.Abs(b) + (level == 2 ? 0 : 0);
+                case "DoubleMerge":
                     // 같은 턴에 한 번 더 합체 시도는 상태머신 훅이 필요하므로 값은 +1로만 처리
                     return Mathf.Max(a, b) + 1 + (level == 2 ? 1 : 0);
                 default: return Mathf.Max(a, b) + 1;

--- a/Assets/Scripts/Systems/WildSystem.cs
+++ b/Assets/Scripts/Systems/WildSystem.cs
@@ -12,6 +12,7 @@ namespace Systems
 
         public void RegisterWildSpec(WildSpec spec) { wilds[spec.id] = spec; }
         public void RegisterUpgradeSpec(UpgradeSpec s) { upgrades[s.id] = s; }
+        public bool TryGetUpgradeSpec(int id, out UpgradeSpec spec) { return upgrades.TryGetValue(id, out spec); }
 
         // 보드에 와일드 스폰
         public bool SpawnWildRandom(BoardController board, int wildSpecId, System.Random rng)


### PR DESCRIPTION
## Summary
- Replace enum-based upgrade effects with data-driven `UpgradeSpec` supporting event triggers
- Apply upgrade effect during merges using new spec and string-based effect types
- Expose upgrade spec lookup through `WildSystem`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b44f423dc833089ee99ae1bf14005